### PR TITLE
Remove prompt nonin

### DIFF
--- a/shell.h
+++ b/shell.h
@@ -6,6 +6,5 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #define PROMPT "($) "
-#define PROMPT2 "$\n"
 int strlen_rec(char *s);
  #endif /* __JKSHELL__ */

--- a/simple_shell.c
+++ b/simple_shell.c
@@ -39,8 +39,6 @@ int main(void)
 /* if interactive mode, print prompt again */
 		if (non == 0)
 			write(STDOUT_FILENO, PROMPT, strlen_rec(PROMPT));
-		if (non == 1)
-			write(STDOUT_FILENO, PROMPT2, strlen_rec(PROMPT2));
 	}
 	free(user_input);
 	return (0);


### PR DESCRIPTION
I misunderstood Holberton's example for non interactive mode and had included a line to be printed before exiting our shell. 
It has been removed.